### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol server for Pixabay image search
 
+<a href="https://glama.ai/mcp/servers/@zym9863/pixabay-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zym9863/pixabay-mcp/badge" alt="Pixabay Server MCP server" />
+</a>
+
 This is a TypeScript-based MCP server that provides access to the Pixabay image API. It demonstrates core MCP concepts by providing:
 
 - Tools for searching images on Pixabay


### PR DESCRIPTION
This PR adds a badge for the [Pixabay MCP Server](https://glama.ai/mcp/servers/@zym9863/pixabay-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zym9863/pixabay-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zym9863/pixabay-mcp/badge" alt="Pixabay Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.